### PR TITLE
feat: [RGInt-303] added no-missing-end-of-source-newline rule to stylelint

### DIFF
--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -16,3 +16,5 @@ Added:
 - add CI checkers: tests, linters checkers
 - add configs and tests
 - add documentation
+
+* no-missing-end-of-source-newline rule to stylelint

--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -10,11 +10,10 @@ and this project adheres to customized Semantic Versioning e.g.: `redwood-rg.1`
 ************
 
 Added:
-=====
+======
+* no-missing-end-of-source-newline rule to stylelint (RGInt-303)
 * initialize project structure and add default configs (RGInt-303)
 
-- add CI checkers: tests, linters checkers
-- add configs and tests
-- add documentation
-
-* no-missing-end-of-source-newline rule to stylelint
+  - add CI checkers: tests, linters checkers
+  - add configs and tests
+  - add documentation

--- a/config/.stylelintrc.js
+++ b/config/.stylelintrc.js
@@ -47,5 +47,6 @@ module.exports = {
     "no-descending-specificity": null,
     "import-notation": null,
     "media-feature-range-notation": null,
+    "no-missing-end-of-source-newline": true,
   },
 };


### PR DESCRIPTION
**Description**
Added `no-missing-end-of-source-newline` rule to stylelint. This rule allows stylelint to check for an empty line at the end of a file.

**Youtrack:** https://youtrack.raccoongang.com/issue/RGInt-303/Frontend-linters-repo