### PR TITLE
fix: allow devDependencies in import/no-extraneous-dependencies rule

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -1,4 +1,10 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { createConfig } = require('@openedx/frontend-build');
 
-module.exports = createConfig('eslint');
+module.exports = {
+  ...createConfig('eslint'),
+  rules: {
+    ...createConfig('eslint').rules,
+    'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
+  },
+};


### PR DESCRIPTION
Override import/no-extraneous-dependencies to set devDependencies: true in the shared ESLint config, so consumer projects no longer need to override this rule locally.