### PR TITLE
docs: document supported Stylelint version range

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ Include `rg-frontend-linters` as a dependency:
 }
 ```
 
+If you use the Stylelint configuration, install the supported Stylelint version in the consuming repository:
+
+```bash
+npm install --save-dev stylelint@^15.6.0
+```
+
+### Stylelint compatibility
+
+The Stylelint configuration supports **Stylelint `^15.6.0`** (versions `>=15.6.0 <16.0.0`).
+
 ### 2. Create a configuration file
 
 Add a configuration file for the desired linter in the root of your project. For example, to configure Stylelint:


### PR DESCRIPTION
## Description

Documents the supported Stylelint version range for repositories consuming the shared Stylelint configuration. Consumer projects can now install `stylelint@^15.6.0` with an explicit documented compatibility range of `>=15.6.0 <16.0.0`.

The supported range was determined from the current `@edx/stylelint-config-edx@^2.3.3` dependency and verified against the local Stylelint configuration. The configuration works with Stylelint 15, while Stylelint 16+ is incompatible because it removes stylistic rules still used by this preset.

## Ticket
https://youtrack.raccoongang.com/issue/ENG-59/RG-Linter-Issues

### Issue 
#3
